### PR TITLE
Enhancements for Seamless Out-of-the-Box Experience with NeoForge MDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'eclipse'
     id 'idea'
     id 'maven-publish'
-    id 'net.minecraftforge.gradle' version '[6.0.12,6.2)'
+    id 'net.neoforged.gradle' version '[6.0.18,6.2)'
 }
 
 version = mod_version
@@ -157,7 +157,7 @@ tasks.named('processResources', ProcessResources).configure {
             forge_version: forge_version, forge_version_range: forge_version_range,
             loader_version_range: loader_version_range,
             mod_id: mod_id, mod_name: mod_name, mod_license: mod_license, mod_version: mod_version,
-            mod_authors: mod_authors, mod_description: mod_description, pack_version_number: pack_version,
+            mod_authors: mod_authors, mod_description: mod_description, pack_format_number: pack_format_number,
     ]
     inputs.properties replaceProperties
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ minecraft_version=1.20.1
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[1.20,1.21)
 # The Forge version must agree with the Minecraft version to get a valid artifact
-forge_version=47.1.7
+forge_version=47.1.25
 # The Forge version range can use any version of Forge as bounds or match the loader version range
 forge_version_range=[47.1,)
 # The loader version range can only use the major version of Forge/FML as bounds
@@ -58,4 +58,4 @@ mod_authors=YourNameHere, OtherNameHere
 # The description of the mod. This is a simple multiline text string that is used for display purposes in the mod list.
 mod_description=Example mod description.\nNewline characters can be used and will be replaced properly.
 # Pack version - this changes each minecraft release, in general.
-pack_version_number=15
+pack_format_number=15


### PR DESCRIPTION
The `pack_version` variable used in the [processResources](https://github.com/neoforged/MDK/blob/572a6977fd740f490cacb01530bd287211b7c174/build.gradle#L154-L167) task does not match the one used in the pack.mcmeta file nor does it match the one in the [gradle.properties](https://github.com/neoforged/MDK/blob/572a6977fd740f490cacb01530bd287211b7c174/gradle.properties#L61).

Since this is the MDK for Neo, it should prob ship with the neo gradle plugin?
Updated to have the latest version of neo gradle `id 'net.minecraftforge.gradle' version '[6.0.12,6.2)'`.

Changed the " `forge_version` " to point to a valid version number of Neo Forge.
With these changes the MDK should work right out of the box where the end user don't have to change anything themselves to make it run.