### PR TITLE
Configure all available ProcessResources tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -151,7 +151,7 @@ dependencies {
 // A missing property will result in an error. Properties are expanded using ${} Groovy notation.
 // When "copyIdeResources" is enabled, this will also run before the game launches in IDE environments.
 // See https://docs.gradle.org/current/dsl/org.gradle.language.jvm.tasks.ProcessResources.html
-tasks.named('processResources', ProcessResources).configure {
+tasks.withType(ProcessResources).configureEach {
     var replaceProperties = [
             minecraft_version   : minecraft_version, minecraft_version_range: minecraft_version_range,
             neo_version         : neo_version, neo_version_range: neo_version_range,


### PR DESCRIPTION
This allows using the properties in resources in the test sourceset automatically, and any other custom sourcesets a modder might declare