### PR TITLE
Add MixinGradle to MDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'idea'
     id 'maven-publish'
     id 'net.neoforged.gradle' version '[6.0.18,6.2)'
+    id 'org.spongepowered.mixin' version '0.7.+'
 }
 
 version = mod_version


### PR DESCRIPTION
As discussed on discord, now that mixingradle is mirrored on the neoforge maven the MDK should include it. Among other things, mixingradle will automatically configure run configs to work with mixin-containing dependencies - meaning that modders don't have to do that manually any more. This PR just adds verison `0.7.+` of the mixingradle plugin; it has been tested by adding a dependency on DynAssetGen (which has mixins that need remapping) in userdev. In the future, I hope that the MDK moves in the direction of reproducible builds, meaning that the `0.7.+` would be replaced with a specific version, but for now it matches what is otherwise used. Let me know if you'd like changes to this.