### PR TITLE
Update setup process

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ mod. Simply create a new repository cloned from this one, by following the
 instructions at [github](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template).
 
 Once you have your clone, simply open the repository in the IDE of your choice. The usual recommendation for an IDE is either IntelliJ IDEA or Eclipse.
-**Note**: On Eclpse you need to run `runClient` first from CLI to make run configs work.
+
+> **Note**: For Eclipse users, you must run the `runClient` task first from the terminal (such as `./gradlew runClient`) for the run configs to work.
 
 If at any point you are missing libraries in your IDE, or you've run into problems you can
 run `gradlew --refresh-dependencies` to refresh the local cache. `gradlew clean` to reset everything 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ instructions at [github](https://docs.github.com/en/repositories/creating-and-ma
 
 Once you have your clone, simply open the repository in the IDE of your choice. The usual recommendation for an IDE is either IntelliJ IDEA or Eclipse.
 
-> **Note**: For Eclipse users, you must run the `runClient` task first from the terminal (such as `./gradlew runClient`) for the run configs to work.
+> **Note**: For IDEs other than Intellij IDEA, you must run the `ideBeforeRun` task first from the terminal (such as `./gradlew ideBeforeRun`) for the run configs to work.
 
 If at any point you are missing libraries in your IDE, or you've run into problems you can
 run `gradlew --refresh-dependencies` to refresh the local cache. `gradlew clean` to reset everything 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This template repository can be directly cloned to get you started with a new
 mod. Simply create a new repository cloned from this one, by following the
 instructions at [github](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template).
 
-Once you have your clone, you can initialize your copy. Then simply open the template in IDE of your choice, we recomment Eclipse and Intellij.
+Once you have your clone, simply open the repository in the IDE of your choice. The usual recommendation for an IDE is either IntelliJ IDEA or Eclipse.
 
 If at any point you are missing libraries in your IDE, or you've run into problems you can 
 run `gradlew --refresh-dependencies` to refresh the local cache. `gradlew clean` to reset everything 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ mod. Simply create a new repository cloned from this one, by following the
 instructions at [github](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template).
 
 Once you have your clone, simply open the repository in the IDE of your choice. The usual recommendation for an IDE is either IntelliJ IDEA or Eclipse.
+**Note**: On Eclpse you need to run `runClient` first from CLI to make run configs work.
 
-If at any point you are missing libraries in your IDE, or you've run into problems you can 
+If at any point you are missing libraries in your IDE, or you've run into problems you can
 run `gradlew --refresh-dependencies` to refresh the local cache. `gradlew clean` to reset everything 
 {this does not affect your code} and then start the process again.
 

--- a/README.md
+++ b/README.md
@@ -6,24 +6,7 @@ This template repository can be directly cloned to get you started with a new
 mod. Simply create a new repository cloned from this one, by following the
 instructions at [github](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template).
 
-Once you have your clone, you can initialize your copy.
-
-Setup Process:
---------
-
-Step 1: Open your command-line and browse to the folder where you extracted cloned your copy of this repository to.
-
-Step 2: You're left with a choice.
-If you prefer to use Eclipse:
-1. Run the following command: `gradlew genEclipseRuns` (`./gradlew genEclipseRuns` if you are on Mac/Linux)
-2. Open Eclipse, Import > Existing Gradle Project > Select Folder 
-   or run `gradlew eclipse` to generate the project.
-
-If you prefer to use IntelliJ:
-1. Open IDEA, and import project.
-2. Select your build.gradle file and have it import.
-3. Run the following command: `gradlew genIntellijRuns` (`./gradlew genIntellijRuns` if you are on Mac/Linux)
-4. Refresh the Gradle Project in IDEA if required.
+Once you have your clone, you can initialize your copy. Then simply open the template in IDE of your choice, we recomment Eclipse and Intellij.
 
 If at any point you are missing libraries in your IDE, or you've run into problems you can 
 run `gradlew --refresh-dependencies` to refresh the local cache. `gradlew clean` to reset everything 


### PR DESCRIPTION
`genIntellijRuns` and `genEclipseRuns` no longer exist and this section should be removed.