### PR TITLE
Remove mapping values from gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,25 +17,6 @@ neo_version=20.2.86
 neo_version_range=[20.2,)
 # The loader version range can only use the major version of Neo/FML as bounds
 loader_version_range=[1,)
-# The mapping channel to use for mappings.
-# The default set of supported mapping channels are ["official", "snapshot", "snapshot_nodoc", "stable", "stable_nodoc"].
-# Additional mapping channels can be registered through the "channelProviders" extension in a Gradle plugin.
-#
-# | Channel   | Version              |                                                                                |
-# |-----------|----------------------|--------------------------------------------------------------------------------|
-# | official  | MCVersion            | Official field/method names from Mojang mapping files                          |
-# | parchment | YYYY.MM.DD-MCVersion | Open community-sourced parameter names and javadocs layered on top of official |
-#
-# You must be aware of the Mojang license when using the 'official' or 'parchment' mappings.
-# See more information here: https://github.com/neoforged/NeoForm/blob/main/Mojang.md
-#
-# Parchment is an unofficial project maintained by ParchmentMC, separate from Minecraft Forge.
-# Additional setup is needed to use their mappings, see https://parchmentmc.org/docs/getting-started
-mapping_channel=official
-# The mapping version to query from the mapping channel.
-# This must match the format required by the mapping channel.
-mapping_version=1.20.2
-
 
 ## Mod Properties
 


### PR DESCRIPTION
Removes the `mapping_channel` and `mapping_version` value from the `gradle.properties` file, as they are no longer used by NeoGradle.