### PR TITLE
Remove final from instanceof check in Config

### DIFF
--- a/src/main/java/com/example/examplemod/Config.java
+++ b/src/main/java/com/example/examplemod/Config.java
@@ -45,7 +45,7 @@ public class Config
 
     private static boolean validateItemName(final Object obj)
     {
-        return obj instanceof final String itemName && BuiltInRegistries.ITEM.containsKey(new ResourceLocation(itemName));
+        return obj instanceof String itemName && BuiltInRegistries.ITEM.containsKey(new ResourceLocation(itemName));
     }
 
     @SubscribeEvent


### PR DESCRIPTION
Eclipse reaaaally hates this `final` here and it looks weird to the rest of us. Since the MDK should work for all IDEs. we should remove that `final`.