### PR TITLE
Clarify purpose of NeoForge.EVENT_BUS.register in ExampleMod class

### DIFF
--- a/src/main/java/com/example/examplemod/ExampleMod.java
+++ b/src/main/java/com/example/examplemod/ExampleMod.java
@@ -76,7 +76,9 @@ public class ExampleMod
         // Register the Deferred Register to the mod event bus so tabs get registered
         CREATIVE_MODE_TABS.register(modEventBus);
 
-        // Register ourselves for server and other game events we are interested in
+        // Register ourselves for server and other game events we are interested in.
+        // Note that this is necessary if and only if we want *this* class (ExampleMod) to respond directly to events.
+        // Do not add this line if there are no @SubscribeEvent-annotated functions in this class, like onServerStarting() below.
         NeoForge.EVENT_BUS.register(this);
 
         // Register the item to a creative tab


### PR DESCRIPTION
It seems like the usage of NeoForge.EVENT_BUS.register may be a common stumbling block. As per a discussion in discord, I added a clarifying comment to the ExampleMod.java file.