### PR TITLE
Removed mention of resolved issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ instructions at [github](https://docs.github.com/en/repositories/creating-and-ma
 
 Once you have your clone, simply open the repository in the IDE of your choice. The usual recommendation for an IDE is either IntelliJ IDEA or Eclipse.
 
-> **Note**: For IDEs other than Intellij IDEA, you must run the `ideBeforeRun` task first from the terminal (such as `./gradlew ideBeforeRun`) for the run configs to work.
-
 If at any point you are missing libraries in your IDE, or you've run into problems you can
 run `gradlew --refresh-dependencies` to refresh the local cache. `gradlew clean` to reset everything 
 {this does not affect your code} and then start the process again.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ instructions at [github](https://docs.github.com/en/repositories/creating-and-ma
 
 Once you have your clone, simply open the repository in the IDE of your choice. The usual recommendation for an IDE is either IntelliJ IDEA or Eclipse.
 
-> **Note**: For Eclipse, Use tasks in `Launch Group` instead of ones founds in `Java Application`. Preparation task must run before launching the game. Neogradle uses Launch groups to do these subsequently.
+> **Note**: For Eclipse, use tasks in `Launch Group` instead of ones founds in `Java Application`. A preparation task must run before launching the game. NeoGradle uses launch groups to do these subsequently.
 
 If at any point you are missing libraries in your IDE, or you've run into problems you can
 run `gradlew --refresh-dependencies` to refresh the local cache. `gradlew clean` to reset everything 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ instructions at [github](https://docs.github.com/en/repositories/creating-and-ma
 
 Once you have your clone, simply open the repository in the IDE of your choice. The usual recommendation for an IDE is either IntelliJ IDEA or Eclipse.
 
+> **Note**: For Eclipse, Use tasks in `Launch Group` instead of ones founds in `Java Application`. Preparation task must run before launching the game. Neogradle uses Launch groups to do these subsequently.
+
 If at any point you are missing libraries in your IDE, or you've run into problems you can
 run `gradlew --refresh-dependencies` to refresh the local cache. `gradlew clean` to reset everything 
 {this does not affect your code} and then start the process again.


### PR DESCRIPTION
On my previous PR(#17) Issue regarding run config was mentioned. However `*ideBeforeRun` tasks are not visible on Eclipse, so no one actually can run it. And it did not specify task names are prepended by run config names such as `clientIdeBeforeRun`
I deleted `.classpath .eclipse .project .settings` from MDK and reimported it on Eclipse and run config worked without `runClient` task. Although preprocessor didn't ran, so I pulled my other mod's toml. but it was not related to the pointed out issue.
Can anybody else also test it out as well?