### PR TITLE
Remove project from resource processing template replacement

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,11 +110,17 @@ dependencies {
 // See https://docs.gradle.org/current/dsl/org.gradle.language.jvm.tasks.ProcessResources.html
 tasks.withType(ProcessResources).configureEach {
     var replaceProperties = [
-            minecraft_version   : minecraft_version, minecraft_version_range: minecraft_version_range,
-            neo_version         : neo_version, neo_version_range: neo_version_range,
-            loader_version_range: loader_version_range,
-            mod_id              : mod_id, mod_name: mod_name, mod_license: mod_license, mod_version: mod_version,
-            mod_authors         : mod_authors, mod_description: mod_description,
+            minecraft_version      : minecraft_version,
+            minecraft_version_range: minecraft_version_range,
+            neo_version            : neo_version,
+            neo_version_range      : neo_version_range,
+            loader_version_range   : loader_version_range,
+            mod_id                 : mod_id,
+            mod_name               : mod_name,
+            mod_license            : mod_license,
+            mod_version            : mod_version,
+            mod_authors            : mod_authors,
+            mod_description        : mod_description
     ]
     inputs.properties replaceProperties
 

--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,7 @@ tasks.withType(ProcessResources).configureEach {
     inputs.properties replaceProperties
 
     filesMatching(['META-INF/mods.toml']) {
-        expand replaceProperties + [project: project]
+        expand replaceProperties
     }
 }
 


### PR DESCRIPTION
The template-expanding done in `processResources` currently contains:

```gradle
filesMatching(['META-INF/mods.toml']) {
    expand replaceProperties + [project: project]
}
```

This causes issues with configuration caching - in addition to those already caused by neogradle - as it uses the `project` object within template expansion; to reach the eventual goal of working configuration caching in a userdev environment, this should be resolved. Specifically, the error is (if you disable the neogradle features that themselves cause failures):

```
luke@luke-kubuntu:~/src/test/MDK$ ./gradlew build --configuration-cache
To honour the JVM settings for this build a single-use Daemon process will be forked. For more on this, please refer to https://docs.gradle.org/8.6/userguide/gradle_daemon.html#sec:disabling_the_daemon in the Gradle documentation.
Daemon will be stopped at the end of the build 
Reusing configuration cache.
> Task :processResources FAILED

FAILURE: Build failed with an exception.

* Where:
Build file '/home/luke/src/test/MDK/build.gradle' line: 122

* What went wrong:
Execution failed for task ':processResources'.
> Cannot reference a Gradle script object from a Groovy closure as these are not supported with the configuration cache.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 3s
1 actionable task: 1 executed
Configuration cache entry reused.
```

Luckily, this expansion isn't actually used anywhere - so the issue can be resolved by only using `replaceProperties` without the added `project` expansion.