### PR TITLE
Respect the archivesName

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,7 @@ tasks.withType(ProcessResources).configureEach {
 publishing {
     publications {
         register('mavenJava', MavenPublication) {
+            artifactId = project.base.archivesName.get()
             from components.java
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 base {
-    archivesName = "${name}-${minecraft_version}"
+    archivesName = "${file_name}-${minecraft_version}"
 }
 
 // Mojang ships Java 17 to end users in 1.18+, so your mod should target Java 17.
@@ -113,7 +113,7 @@ tasks.withType(ProcessResources).configureEach {
             minecraft_version   : minecraft_version, minecraft_version_range: minecraft_version_range,
             neo_version         : neo_version, neo_version_range: neo_version_range,
             loader_version_range: loader_version_range,
-            mod_id              : mod_id, mod_name: mod_name, mod_license: mod_license, mod_version: mod_version,
+            mod_id              : mod_id, mod_name: mod_name, file_name: file_name, mod_license: mod_license, mod_version: mod_version,
             mod_authors         : mod_authors, mod_description: mod_description,
     ]
     inputs.properties replaceProperties

--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ tasks.withType(ProcessResources).configureEach {
             minecraft_version   : minecraft_version, minecraft_version_range: minecraft_version_range,
             neo_version         : neo_version, neo_version_range: neo_version_range,
             loader_version_range: loader_version_range,
-            mod_id              : mod_id, mod_name: mod_name, file_name: file_name, mod_license: mod_license, mod_version: mod_version,
+            mod_id              : mod_id, mod_name: mod_name, mod_license: mod_license, mod_version: mod_version,
             mod_authors         : mod_authors, mod_description: mod_description,
     ]
     inputs.properties replaceProperties
@@ -123,10 +123,12 @@ tasks.withType(ProcessResources).configureEach {
     }
 }
 
-// Example configuration to allow publishing using the maven-publish plugin
+// Build and publish a -sources.jar as well (useful for addons)
 java {
     withSourcesJar()
 }
+
+// Example configuration to allow publishing using the maven-publish plugin
 publishing {
     publications {
         register('mavenJava', MavenPublication) {

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 base {
-    archivesName = mod_id
+    archivesName = "${name}-${minecraft_version}"
 }
 
 // Mojang ships Java 17 to end users in 1.18+, so your mod should target Java 17.
@@ -124,6 +124,9 @@ tasks.withType(ProcessResources).configureEach {
 }
 
 // Example configuration to allow publishing using the maven-publish plugin
+java {
+    withSourcesJar()
+}
 publishing {
     publications {
         register('mavenJava', MavenPublication) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,6 +29,8 @@ loader_version_range=[2,)
 mod_id=examplemod
 # The human-readable display name for the mod.
 mod_name=Example Mod
+# The mod filename, usually the mod_id or the mod_name WithoutSpaces
+file_name=ExampleMod
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=All Rights Reserved
 # The mod version. See https://semver.org/


### PR DESCRIPTION
I'm not a gradle expert, so I'm not sure if there's a better way to do this, but at least with userdev 7.0.97 (as is referenced here), changes to the `base.archivesName` don't actually do anything without a line like this.