### PR TITLE
Configure idea to download sources and javadoc jars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,3 +146,11 @@ publishing {
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8' // Use the UTF-8 charset for Java compilation
 }
+
+// IDEA no longer automatically downloads sources/javadoc jars for dependencies, so we need to explicitly enable the behavior.
+idea {
+    module {
+        downloadSources = true
+        downloadJavadoc = true
+    }
+}


### PR DESCRIPTION
Not sure exactly what version of IDEA changed the default behavior, but this should solve a lot of headaches for folks