### PR TITLE
Use a default `AFTER` ordering for the NeoForge dependency

### DIFF
--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -70,9 +70,10 @@ description='''${mod_description}'''
     # The version range of the dependency
     versionRange="${neo_version_range}" #mandatory
     # An ordering relationship for the dependency.
+    # NONE - No ordering is specified between this mod and the dependency
     # BEFORE - This mod is loaded BEFORE the dependency
     # AFTER - This mod is loaded AFTER the dependency
-    ordering="NONE"
+    ordering="AFTER"
     # Side this dependency is applied on - BOTH, CLIENT, or SERVER
     side="BOTH"
 


### PR DESCRIPTION
Modders will almost always want their own data loaded after NeoForge's data is loaded. Using a default of `NONE` will seemingly break modder's data when trying to override recipes or other data that NeoForge overrides or implements itself. Using a default order of `AFTER` in the MDK itself will prevent these issues from cropping up and create a more pleasant experience while working with the mod loader.