### PR TITLE
[MDG] Remove old `--existing` data parameter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,8 +70,8 @@ neoForge {
             // example of overriding the workingDirectory set in configureEach above, uncomment if you want to use it
             // gameDirectory = project.file('run-data')
 
-            // Specify the modid for data generation, where to output the resulting resource, and where to look for existing resources.
-            programArguments.addAll '--mod', project.mod_id, '--all', '--output', file('src/generated/resources/').getAbsolutePath(), '--existing', file('src/main/resources/').getAbsolutePath()
+            // Specify the modid for data generation, where to output the resulting resource
+            programArguments.addAll '--mod', project.mod_id, '--all', '--output', file('src/generated/resources/').getAbsolutePath()
         }
 
         // applies to all the run configs above


### PR DESCRIPTION
Removes the old `--existing` parameter from the data run config

Requires [NeoForge#1799](https://github.com/neoforged/NeoForge/pull/1799)