### PR TITLE
Enable gradle daemon

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Sets default memory used for gradle commands. Can be overridden by user or command line properties.
 org.gradle.jvmargs=-Xmx1G
-org.gradle.daemon=false
+org.gradle.daemon=true
 org.gradle.debug=false
 
 #read more on this at https://github.com/neoforged/NeoGradle/blob/NG_7.0/README.md#apply-parchment-mappings


### PR DESCRIPTION
NG7 is compatible with the daemon, and having a running daemon makes invoking gradle substantially faster, which is especially relevant if running gradle tasks before IDE runs or the like.

Note that "disabling the daemon" actually just means "using a one-time use daemon"; it's not as if doing so would save any performance even on the first invocation of gradle