### PR TITLE
add colored output to the terminal using `teminal.jline`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,11 @@ neoForge {
             // "REGISTRYDUMP": For getting the contents of all registries.
             systemProperty 'forge.logging.markers', 'REGISTRIES'
 
+            // Enables colored output in the terminal.
+            // If JLine doesn't work, try using the below line instead (comment the other out):
+            //systemProperty 'terminal.ansi', 'true'
+            systemProperty 'terminal.jline', 'true'
+
             // Recommended logging level for the console
             // You can set various levels here.
             // Please read: https://stackoverflow.com/questions/2031163/when-to-use-the-different-log-levels


### PR DESCRIPTION
simply the title, if you're curious as to where the property is read, see `TerminalConsoleAppender#JLINE_OVERRIDE_PROPERTY`